### PR TITLE
Use a special branch to push test images to quay

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - test_and_push
 
 jobs:
   build:


### PR DESCRIPTION
This is a little helper to hopefully test big images that can not be tested on Binder but still build successfully on the CI.
I am going to merge this one quickly since this is an experiment that I can easily revert and let me iterate on #7.