### PR TITLE
Use docker push instead of r2d pushing capabilties.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - test_and_push
 
 jobs:
   build:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,4 +27,4 @@ jobs:
         password: ${{ secrets.QUAY_PASSWORD }}
 
     - name: docker push
-      run: docker push 2i2c/utoronto-image:test
+      run: docker push quay.io/2i2c/utoronto-image:test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,4 @@
-name: Build container image
+name: Test container image
 
 on:
   pull_request:
@@ -17,3 +17,14 @@ jobs:
         NO_PUSH: "true"
         DOCKER_REGISTRY: "quay.io"
         IMAGE_NAME: "2i2c/utoronto-image"
+        ADDITIONAL_TAG: "test"
+
+    - name: login to Quay.io
+      uses: docker/login-action@v1
+      with:
+        registry: quay.io
+        username: ${{ secrets.QUAY_USERNAME }}
+        password: ${{ secrets.QUAY_PASSWORD }}
+
+    - name: docker push
+      run: docker push 2i2c/utoronto-image:test


### PR DESCRIPTION
On #7 I found the image push is timeout, more details here: https://github.com/2i2c-org/utoronto-image/pull/7#issuecomment-1013235065

This is effectively reverting the #8 experiment and trying to use docker for the push event.