### PR TITLE
Push built image manually

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,10 +24,15 @@ jobs:
 
     - name: Update jupyter dependencies with repo2docker
       uses: jupyterhub/repo2docker-action@master
+      id: r2d
       with:
         # Make sure username & password/token pair matches your registry credentials
         DOCKER_USERNAME: ${{ secrets.QUAY_USERNAME }}
         DOCKER_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
         DOCKER_REGISTRY: "quay.io"
-
+        NO_PUSH: "true"
         IMAGE_NAME: "2i2c/utoronto-image"
+
+    - name: docker push
+      # FIXME: Due to timeouts in the r2d action, we push manually
+      run: docker push ${{ steps.r2d.outputs.IMAGE_SHA_NAME }}


### PR DESCRIPTION
Temporary, until we can set the push timeout in r2d properly

Fixes https://github.com/2i2c-org/utoronto-image/issues/20