### PR TITLE
Use r2d-action to push to registry

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,14 +23,13 @@ jobs:
       uses: actions/checkout@main
 
     - name: Update jupyter dependencies with repo2docker
-      uses: yuvipanda/repo2docker-action@fix-output
+      uses: yuvipanda/repo2docker-action@docker-push
       id: r2d
       with:
         # Make sure username & password/token pair matches your registry credentials
         DOCKER_USERNAME: ${{ secrets.QUAY_USERNAME }}
         DOCKER_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
         DOCKER_REGISTRY: "quay.io"
-        NO_PUSH: "true"
         IMAGE_NAME: "2i2c/utoronto-image"
 
     - name: Login to Quay.io
@@ -39,7 +38,3 @@ jobs:
         registry: quay.io
         username: ${{ secrets.QUAY_USERNAME }}
         password: ${{ secrets.QUAY_PASSWORD }}
-
-    - name: docker push
-      # FIXME: Due to timeouts in the r2d action, we push manually
-      run: docker push ${{ steps.r2d.outputs.IMAGE_SHA_NAME }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@main
 
     - name: update jupyter dependencies with repo2docker
-      uses: jupyterhub/repo2docker-action@master
+      uses: yuvipanda/repo2docker-action@docker-push
       with: # make sure username & password/token matches your registry
         NO_PUSH: "true"
         DOCKER_REGISTRY: "quay.io"


### PR DESCRIPTION
Brings in https://github.com/jupyterhub/repo2docker-action/pull/85,
which just uses docker push in upstream r2d-action to fix
the timeout issues.