### PR TITLE
Use repo2docker to push test image tag too

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,7 +22,7 @@ jobs:
     - name: Checkout files in repo
       uses: actions/checkout@main
 
-    - name: Update jupyter dependencies with repo2docker
+    - name: Build and push the image
       uses: yuvipanda/repo2docker-action@docker-push
       id: r2d
       with:
@@ -32,9 +32,5 @@ jobs:
         DOCKER_REGISTRY: "quay.io"
         IMAGE_NAME: "2i2c/utoronto-image"
 
-    - name: Login to Quay.io
-      uses: docker/login-action@v1
-      with:
-        registry: quay.io
-        username: ${{ secrets.QUAY_USERNAME }}
-        password: ${{ secrets.QUAY_PASSWORD }}
+    - name: Report disk space
+      run: df -h

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,23 +20,14 @@ jobs:
     - name: checkout files in repo
       uses: actions/checkout@main
 
-    - name: update jupyter dependencies with repo2docker
+    - name: Build and push the image
       uses: yuvipanda/repo2docker-action@docker-push
-      with: # make sure username & password/token matches your registry
-        NO_PUSH: "true"
+      with:
+        DOCKER_USERNAME: ${{ secrets.QUAY_USERNAME }}
+        DOCKER_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
         DOCKER_REGISTRY: "quay.io"
         IMAGE_NAME: "2i2c/utoronto-image"
         ADDITIONAL_TAG: "test"
-
-    - name: login to Quay.io
-      uses: docker/login-action@v1
-      with:
-        registry: quay.io
-        username: ${{ secrets.QUAY_USERNAME }}
-        password: ${{ secrets.QUAY_PASSWORD }}
-
-    - name: docker push
-      run: docker push quay.io/2i2c/utoronto-image:test
 
     - name: Report disk space
       run: df -h


### PR DESCRIPTION
- Remove unnecessary login to quay.io
- Reword image build step to be clearer on what it does
- Reinstate df -h step so we know how much space is left and
  if we will run into disk space issues on GitHub actions again