### PR TITLE
Bump reticulate version

### DIFF
--- a/install.R
+++ b/install.R
@@ -12,7 +12,7 @@ cran_packages <- c(
   "knitr", "1.37",
   "rmarkdown", "2.11",
   "Rcpp", "1.0.7",
-  "reticulate", "1.22",
+  "reticulate", "1.24",
   "openintro", "2.2.0",
   "gridExtra", "2.3",
   "BHH2", "2016.05.31",


### PR DESCRIPTION
I am hoping this will solve the error reported in https://2i2c.freshdesk.com/a/tickets/65

Somehow, this issue disappeared for me when I tried to load the dataset in a new RStudio session.
Anyway, this looks to be an issue with Python not being able to find and use the correct location of openssl from the conda env we use in R.

I'm hoping the newest version of reticulate would have solved this issue. I'm interested in particular in bringing in this change https://github.com/rstudio/reticulate/pull/1053.

🤞🏼 