### PR TITLE
Add textblob & bump to jupyterhub 3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -194,7 +194,12 @@ COPY environment.yml /tmp/
 
 RUN mamba env update -p ${CONDA_DIR} -f /tmp/environment.yml && mamba clean -afy
 # For https://2i2c.freshdesk.com/a/tickets/187
-RUN python -m textblob.download_corpora
+# If we don't set `NLTK_DATA`, the data gets downloaded onto $HOME, which
+# isn't available when the image is loaded onto JupyterHub.
+# So we download alongside our packages.
+# Note that textblob.download_corpora just calls nltk to download corpora
+ENV NLTK_DATA ${CONDA_DIR}/nltk_data
+RUN mkdir -p ${NLTK_DATA} && python -m textblob.download_corpora
 
 COPY install-jupyter-extensions.bash /tmp/install-jupyter-extensions.bash
 RUN /tmp/install-jupyter-extensions.bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -193,6 +193,8 @@ RUN /tmp/install-bioconductor.R && \
 COPY environment.yml /tmp/
 
 RUN mamba env update -p ${CONDA_DIR} -f /tmp/environment.yml && mamba clean -afy
+# For https://2i2c.freshdesk.com/a/tickets/187
+RUN python -m textblob.download_corpora
 
 COPY install-jupyter-extensions.bash /tmp/install-jupyter-extensions.bash
 RUN /tmp/install-jupyter-extensions.bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -185,6 +185,11 @@ COPY install.R /tmp/install.R
 RUN /tmp/install.R && \
 	rm -rf /tmp/downloaded_packages/ /tmp/*.rds
 
+# Install bioconductor separately, as it seems to fail often
+COPY install-bioconductor.R /tmp/install-bioconductor.R
+RUN /tmp/install-bioconductor.R && \
+	rm -rf /tmp/downloaded_packages/ /tmp/*.rds
+
 COPY environment.yml /tmp/
 
 RUN mamba env update -p ${CONDA_DIR} -f /tmp/environment.yml && mamba clean -afy

--- a/environment.yml
+++ b/environment.yml
@@ -63,3 +63,6 @@ dependencies:
 
     # From https://2i2c.freshdesk.com/a/tickets/57
     - jax[cpu]
+
+    # From https://2i2c.freshdesk.com/a/tickets/187
+    - textblob==0.17.1

--- a/environment.yml
+++ b/environment.yml
@@ -7,24 +7,24 @@ dependencies:
   # language runtimes
   - python=3.8.*
 
-  - numpy
-  - scipy
-  - matplotlib
-  - pandas
-  - seaborn
-  - sympy
-  - networkx
-  - scikit-learn
-  - beautifulsoup4
-  - statsmodels
-  - nltk
-  - spacy
-  - geopandas
+  - numpy==1.22.*
+  - scipy==1.8.*
+  - matplotlib==3.5.*
+  - pandas==1.4.*
+  - seaborn==0.11.*
+  - sympy==1.10
+  - networkx==2.7.*
+  - scikit-learn==1.0.*
+  - beautifulsoup4==4.10.*
+  - statsmodels==0.13.*
+  - nltk==3.6.*
+  - spacy==3.2.*
+  - geopandas==0.10.*
   # From https://github.com/utoronto-2i2c/jupyterhub-deploy/issues/29
-  - astroquery
-  - astropy
-  - galpy
-  - libgfortran
+  - astroquery==0.4.5
+  - astropy==5.0.*
+  - galpy==1.7.*
+  - libgfortran==3.0.0
 
   - pip<20.3
 

--- a/environment.yml
+++ b/environment.yml
@@ -41,7 +41,7 @@ dependencies:
     - jupyter-desktop-server==0.1.3
     - git-credential-helpers==0.2
     - notebook==6.4.7
-    - jupyterhub==1.5.0
+    - jupyterhub==2.3.1
     - jupyter-server-proxy==3.2.0
     - jupyter-rsession-proxy==1.4
     - jupyter-shiny-proxy==1.1

--- a/environment.yml
+++ b/environment.yml
@@ -41,7 +41,7 @@ dependencies:
     - jupyter-desktop-server==0.1.3
     - git-credential-helpers==0.2
     - notebook==6.4.7
-    - jupyterhub==2.3.1
+    - jupyterhub==3.0.0
     - jupyter-server-proxy==3.2.0
     - jupyter-rsession-proxy==1.4
     - jupyter-shiny-proxy==1.1

--- a/install-bioconductor.R
+++ b/install-bioconductor.R
@@ -1,0 +1,11 @@
+#!/usr/bin/env r
+
+# Install a version of locfit compatible with edgeR & R 4.0
+devtools::install_version('locfit', '1.5-9.1')
+
+# Install biocmanager version 3.12, for R 4.0
+BiocManager::install(version = '3.12')
+# Install packages from bioconductor
+BiocManager::install(c(
+  "edgeR"
+))

--- a/install.R
+++ b/install.R
@@ -134,11 +134,3 @@ for (i in seq(1, length(github_packages), 2)) {
     ref = github_packages[i + 1]
   )
 }
-
-
-# Install biocmanager version 3.12, for R 4.0
-BiocManager::install(version = '3.12')
-# Install packages from bioconductor
-BiocManager::install(c(
-  "edgeR"
-))


### PR DESCRIPTION
- Move bioconductor install to separate file, so we don't end up
  busting the general R cache each time we need to fiddle with
  bioconductor
- Explicitly install an older version of locfit so bioconductor can
  install edgeR
- Install newer version of jupyterhub, so interface selection works
  again
- Install textblob

Fixes #33 