### PR TITLE
Switch from conda to mamba

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -112,8 +112,8 @@ RUN apt-get update -qq --yes && \
 
 WORKDIR /home/jovyan
 
-COPY install-miniforge.bash /tmp/install-miniforge.bash
-RUN /tmp/install-miniforge.bash
+COPY install-mambaforge.bash /tmp/install-mambaforge.bash
+RUN /tmp/install-mambaforge.bash
 
 # Needed by RStudio
 RUN apt-get update -qq --yes && \
@@ -187,7 +187,7 @@ RUN /tmp/install.R && \
 
 COPY environment.yml /tmp/
 
-RUN conda env update -p ${CONDA_DIR} -f /tmp/environment.yml && conda clean -afy
+RUN mamba env update -p ${CONDA_DIR} -f /tmp/environment.yml && mamba clean -afy
 
 COPY install-jupyter-extensions.bash /tmp/install-jupyter-extensions.bash
 RUN /tmp/install-jupyter-extensions.bash

--- a/install-mambaforge.bash
+++ b/install-mambaforge.bash
@@ -1,12 +1,12 @@
 #!/bin/bash
-# This downloads and installs a pinned version of miniconda
+# This downloads and installs a pinned version of mambaforge
 set -ex
 
 cd $(dirname $0)
-MINIFORGE_VERSION=4.8.3-5
+MAMBAFORGE_VERSION=4.10.3-7
 
-URL="https://github.com/conda-forge/miniforge/releases/download/4.8.3-5/Miniforge3-${MINIFORGE_VERSION}-Linux-x86_64.sh"
-INSTALLER_PATH=/tmp/miniforge-installer.sh
+URL="https://github.com/conda-forge/miniforge/releases/download/${MAMBAFORGE_VERSION}/Mambaforge-${MAMBAFORGE_VERSION}-Linux-x86_64.sh"
+INSTALLER_PATH=/tmp/mambaforge-installer.sh
 
 # make sure we don't do anything funky with user's $HOME
 # since this is run as root
@@ -34,7 +34,7 @@ conda clean --all -f -y
 # Remove the big installer so we don't increase docker image size too much
 rm ${INSTALLER_PATH}
 
-# Remove the pip cache created as part of installing miniconda
+# Remove the pip cache created as part of installing mambaforge
 rm -rf /root/.cache
 
 chown -R $NB_USER:$NB_USER ${CONDA_DIR}

--- a/install.R
+++ b/install.R
@@ -46,7 +46,7 @@ cran_packages <- c(
   "janitor", "2.1.0",
   "kableExtra", "1.3.4",
   "lme4", "1.1-27.1",
-  "Matching", "4.9-11",
+  "Matching", "4.10-2",
   "multcomp", "1.4-18",
   "partitions", "1.10-4",
   "pheatmap", "1.0.12",


### PR DESCRIPTION
This gets the commits from https://github.com/2i2c-org/utoronto-image/pull/31 that should make the image size smaller  so we can build it using the CI/CD again 🤞🏼 