### PR TITLE
Add markus-jupyter-extension to Python environment

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -59,7 +59,7 @@ dependencies:
 
     # nbextensions
     - jupyterthemes==0.20.0
-    - markus-jupyter-extension==0.1.*
+    - markus-jupyter-extension==0.1.1
 
     # From https://2i2c.freshdesk.com/a/tickets/57
     - jax[cpu]

--- a/environment.yml
+++ b/environment.yml
@@ -59,6 +59,7 @@ dependencies:
 
     # nbextensions
     - jupyterthemes==0.20.0
+    - markus-jupyter-extension==0.1.*
 
     # From https://2i2c.freshdesk.com/a/tickets/57
     - jax[cpu]


### PR DESCRIPTION
Hello! I'd like to add the [markus-jupyter-extension](https://github.com/MarkUsProject/markus-jupyter-extension) nbextension to the image. This will help reduce the friction students have when submitting their work from JupyterHub to MarkUs (the grading platform we're using in a few different data science courses).

Please let me know if there's anything I can help with to get this merged in!