### PR TITLE
Bump markus-jupyter-extension to v0.1.2

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -59,7 +59,7 @@ dependencies:
 
     # nbextensions
     - jupyterthemes==0.20.0
-    - markus-jupyter-extension==0.1.1
+    - markus-jupyter-extension==0.1.2
 
     # From https://2i2c.freshdesk.com/a/tickets/57
     - jax[cpu]


### PR DESCRIPTION
I've released an updated version of markus-jupyter-extension to get the extension to be automatically installed and enabled when the package is installed.

Thanks for the reference @yuvipanda!