### PR TITLE
Pin jupyterlab to 3.5.x

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -30,7 +30,7 @@ dependencies:
   - tensorflow==2.10.0
    
   # Infrastructure things
-  - jupyterlab==3.*
+  - jupyterlab==3.5.*
   - retrolab==0.3.*
   - voila==0.3.*
   - nbgitpuller==1.1.*

--- a/environment.yml
+++ b/environment.yml
@@ -30,7 +30,7 @@ dependencies:
   - tensorflow==2.10.0
    
   # Infrastructure things
-  - jupyterlab==3.5.*
+  - jupyterlab==3.5.* # Pinned to <3.6, until https://github.com/2i2c-org/infrastructure/issues/2244 is fixed
   - retrolab==0.3.*
   - voila==0.3.*
   - nbgitpuller==1.1.*


### PR DESCRIPTION
Workaround for IO errors seen

Debugging points to 3.6 pulls in  jupyter-server-fileid