### PR TITLE
Pin nbclassic<0.5 to get nbcontrib extensions to work

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -31,6 +31,9 @@ dependencies:
    
   # Infrastructure things
   - jupyterlab==3.5.* # Pinned to <3.6, until https://github.com/2i2c-org/infrastructure/issues/2244 is fixed
+  # Pinned until https://github.com/Jupyter-contrib/jupyter_nbextensions_configurator/pull/152 can land
+  # See https://github.com/2i2c-org/infrastructure/issues/2380
+  - nbclassic<0.5
   - retrolab==0.3.*
   - voila==0.3.*
   - nbgitpuller==1.1.*


### PR DESCRIPTION
Ref https://github.com/2i2c-org/infrastructure/issues/2380

Can be removed once https://github.com/Jupyter-contrib/jupyter_nbextensions_configurator/pull/152 is fixed.