### PR TITLE
Try enabling nbextensions_configurator explicitly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,3 +32,7 @@ RUN mamba env update -p ${CONDA_DIR} -f /tmp/environment.yml && mamba clean -afy
 # Note that textblob.download_corpora just calls nltk to download corpora
 ENV NLTK_DATA ${CONDA_DIR}/nltk_data
 RUN mkdir -p ${NLTK_DATA} && python -m textblob.download_corpora
+
+RUN jupyter nbclassic-extension install --sys-prefix --py jupyter_nbextensions_configurator --overwrite && \
+    jupyter nbclassic-extension enable --sys-prefix --py jupyter_nbextensions_configurator && \
+    jupyter nbclassic-serverextension enable --sys-prefix --py jupyter_nbextensions_configurator


### PR DESCRIPTION
May allow us to switch to jupyter server here too. I had to remove the nbclassic-serverextension install line from here: https://github.com/Jupyter-contrib/jupyter_nbextensions_configurator/issues/153