### PR TITLE
Bump jupyterhub version explicitly

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -76,3 +76,6 @@ dependencies:
 
       # Added as part of a support request (TBA freshdesk link)
       - kaleido==0.2.*
+
+      # Bump up jupyterhub explicitly to handle https://github.com/jupyterhub/jupyterhub/issues/4629
+      - jupyterhub>5


### PR DESCRIPTION
Handles https://github.com/jupyterhub/jupyterhub/issues/4629, causing 'blank screen' errors when OOM kills happen.

Reported in https://2i2c.freshdesk.com/a/tickets/3183