### PR TITLE
Bump jupyter-resource-use

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -21,7 +21,7 @@ dependencies:
   # Infrastructure things
   - nbgitpuller==1.2.*
   - nbconvert-webpdf
-  - jupyter-resource-usage==1.0.*
+  - jupyter-resource-usage==1.1.*
   - jupytext==1.15.*
   - jupyter-server-proxy>=4.1.2,4.*
 


### PR DESCRIPTION
This seems to currently fail with the newest JupyterHub, with errors like:

```
[W 2025-04-23 22:37:23.932 ServerApp] wrote error: 'Forbidden'
    Traceback (most recent call last):
      File "/opt/conda/lib/python3.11/site-packages/tornado/web.py", line 1784, in _execute
        result = method(*self.path_args, **self.path_kwargs)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/opt/conda/lib/python3.11/site-packages/tornado/web.py", line 3278, in wrapper
        url = self.get_login_url()
              ^^^^^^^^^^^^^^^^^^^^
      File "/opt/conda/lib/python3.11/site-packages/jupyterhub/singleuser/extension.py", line 146, in get_login_url
        login_url = original_get_login_url()
                    ^^^^^^^^^^^^^^^^^^^^^^^^
      File "/opt/conda/lib/python3.11/site-packages/jupyter_server/base/handlers.py", line 762, in get_login_url
        raise web.HTTPError(403)
    tornado.web.HTTPError: HTTP 403: Forbidden
```