### PR TITLE
Unbump jupyter-resource-usage

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -21,7 +21,7 @@ dependencies:
   # Infrastructure things
   - nbgitpuller==1.2.*
   - nbconvert-webpdf
-  - jupyter-resource-usage==1.1.*
+  - jupyter-resource-usage==1.0.*
   - jupytext==1.15.*
   - jupyter-server-proxy>=4.1.2,4.*
 


### PR DESCRIPTION
I think the newer version doesn't provide a classic notebook component